### PR TITLE
Depend on x-is-array directly.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "es6-map": "0.1.1",
     "vdom-parser": "^1.0.2",
     "vdom-to-html": "^2.0.0",
-    "virtual-dom": "2.1.0"
+    "virtual-dom": "2.1.0",
+    "x-is-array": "0.1.0"
   },
   "peerDependencies": {
     "@cycle/core": "1.0.x"

--- a/src/virtual-hyperscript.js
+++ b/src/virtual-hyperscript.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-var isArray = require('virtual-dom/node_modules/x-is-array');
+var isArray = require('x-is-array');
 
 var VNode = require('virtual-dom/vnode/vnode.js');
 var VText = require('virtual-dom/vnode/vtext.js');


### PR DESCRIPTION
Requiring `x-is-array` fron inside `virtual-dom`’s depnencies breaks on an npm 3.x install, since npm 3 moves `x-is-array` to the top level when installing. `virtual-dom` itself depends on the `x-is-array` module as published on npm, so the code should be identical.