### PR TITLE
feat(DOM): add support for `useCapture` events

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
   "main": "lib/cycle-dom.js",
   "dependencies": {
     "es6-map": "0.1.1",
+    "matches-selector": "1.0.x",
+    "rx-dom": "^6.0.0",
     "vdom-parser": "^1.0.2",
     "vdom-to-html": "^2.0.0",
     "virtual-dom": "2.1.1",
-    "x-is-array": "0.1.0",
-    "matches-selector": "1.0.x"
+    "x-is-array": "0.1.0"
   },
   "peerDependencies": {
     "@cycle/core": "3.x.x"

--- a/src/render-dom.js
+++ b/src/render-dom.js
@@ -1,4 +1,5 @@
 let {Rx} = require(`@cycle/core`)
+Rx = typeof window !== `undefined` ? require(`rx-dom`) : Rx
 let VDOM = {
   h: require(`./virtual-hyperscript`),
   diff: require(`virtual-dom/diff`),
@@ -182,7 +183,7 @@ function makeResponseGetter(rootElem$) {
 }
 
 function makeEventsSelector(element$) {
-  return function events(eventName) {
+  return function events(eventName, useCapture = false) {
     if (typeof eventName !== `string`) {
       throw new Error(`DOM driver's get() expects second argument to be a ` +
         `string representing the event type to listen for.`)
@@ -191,7 +192,7 @@ function makeEventsSelector(element$) {
       if (!element) {
         return Rx.Observable.empty()
       }
-      return Rx.Observable.fromEvent(element, eventName)
+      return Rx.DOM.fromEvent(element, eventName, useCapture)
     }).share()
   }
 }


### PR DESCRIPTION
Add rx-dom library.

events method now takes an optional `useCapture` argument which defaults to `false`.

Reference #41 