### PR TITLE
chore(package): update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,20 +21,20 @@
   ],
   "main": "lib/cycle-dom.js",
   "dependencies": {
-    "es6-map": "0.1.1",
-    "hyperscript-helpers": "^2.0.2",
+    "hyperscript-helpers": "2.0.2",
     "matches-selector": "1.0.0",
     "vdom-parser": "1.2.1",
-    "vdom-to-html": "2.1.1",
+    "vdom-to-html": "2.2.0",
     "virtual-dom": "2.1.1",
     "x-is-array": "0.1.0"
   },
   "devDependencies": {
     "@cycle/core": "6.0.0-rc1",
-    "babel": "5.8.23",
-    "babelify": "6.3.0",
-    "browserify": "11.2.0",
-    "browserify-shim": "^3.8.10",
+    "babel": "5.8.29",
+    "babelify": "6.4.0",
+    "browserify": "12.0.1",
+    "browserify-shim": "3.8.11",
+    "es6-map": "0.1.2",
     "eslint": "1.0.0",
     "eslint-config-cycle": "3.1.0",
     "eslint-plugin-cycle": "1.0.2",
@@ -42,9 +42,9 @@
     "markdox": "0.1.10",
     "mocha": "2.3.3",
     "rx": "4.0.6",
-    "testem": "0.9.8",
+    "testem": "0.9.11",
     "uglify-js": "2.5.0",
-    "zuul": "3.6.0"
+    "zuul": "3.7.2"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
vdom-to-html 2.1.1 => 2.2.0
babel 5.8.23 => 5.8.29
babelify 6.3.0 => 6.4.0
browserify 11.2.0 => 12.0.1
testem 0.9.8 => 0.9.11
zuul 3.6.0 => 3.7.2

Version-lock hyperscript-helpers
Move es6-map to devDependencies
Version-lock browserify-shim

Note: updating babel to v6.x.x is unleashing build errors
with no obvious fixes. I recommend to defer major update.

References https://github.com/cyclejs/cycle-core/issues/188