### PR TITLE
fix classList access for SVG elements on iOS6

### DIFF
--- a/src/render-dom.js
+++ b/src/render-dom.js
@@ -83,7 +83,7 @@ function makeIsStrictlyInRootScope(rootList, namespace) {
         return true
       }
 
-      const classList = el.classList || el.className.split(` `)
+      const classList = el.classList || String.prototype.split.call(el.className, ` `)
       if (Array.prototype.some.call(classList, classIsForeign)) {
         return false
       }


### PR DESCRIPTION
The `className` of an SVG element is not a real String and provides no split method. That's why I introduced the usage of `classList` in #67.

Now I noticed that the Webkit version used in iOS6 does not implement classList for SVG elements.
Calling the `String.prototype.split` method explicitly works for both `String` and `SVGAnimatedString`.

I am not sure if we should remove the usage of `classList` and just use `String.prototype.split`.
I think using `el.classList` as default if available is best because it expresses the intent and explicitly states the `split` call as fallback.