### PR TITLE
Fix a bug in isolateSink() (auto-scope branch)

### DIFF
--- a/src/render-dom.js
+++ b/src/render-dom.js
@@ -66,7 +66,8 @@ function isolateSource(source, scope) {
 
 function isolateSink(sink, scope) {
   return sink.map(vtree => {
-    const c = `${vtree.properties.className} cycle-scope-${scope}`.trim()
+    const {className: vtreeClass = ``} = vtree.properties
+    const c = `${vtreeClass} cycle-scope-${scope}`.trim()
     vtree.properties.className = c
     return vtree
   })


### PR DESCRIPTION
This commit fix a bug below.

if a ```vtree``` has no class name, ```vtree.properties.className```
will be ```undefined```. (this comes from virtual-dom)

In this case, vtree.properties.className will be like
```"undefined cycle-scope-0"``` which we want to be just ```"cycle-scope-0"```
After all, rendered DOM will be like ```<div class="undefined cycle-scope-0"></div>```