### PR TITLE
Add ownerTarget property to events, clone of currentTarget

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -13,7 +13,7 @@ browsers:
   - name: safari
     version: 7..latest
   - name: ie
-    version: 9..latest
+    version: 10..latest
   - name: android
     version: '4.4..latest'
   - name: iphone

--- a/src/render-dom.js
+++ b/src/render-dom.js
@@ -130,10 +130,15 @@ function maybeMutateEventPropagationAttributes(event) {
 }
 
 function mutateEventCurrentTarget(event, currentTargetElement) {
-  Object.defineProperty(event, `currentTarget`, {
-    value: currentTargetElement,
-    configurable: true,
-  })
+  try {
+    Object.defineProperty(event, `currentTarget`, {
+      value: currentTargetElement,
+      configurable: true,
+    })
+  } catch (err) {
+    void err // noop
+  }
+  event.ownerTarget = currentTargetElement
 }
 
 function makeSimulateBubbling(namespace, rootEl) {

--- a/test/browser/events.js
+++ b/test/browser/events.js
@@ -262,7 +262,7 @@ describe('DOMSource.events()', function () {
       });
   });
 
-  it('should have currentTarget pointed to the selected parent', function (done) {
+  it('should have currentTarget or ownerTarget pointed to the selected parent', function (done) {
     function app() {
       return {
         DOM: Rx.Observable.just(div('.top', [
@@ -282,8 +282,11 @@ describe('DOMSource.events()', function () {
       assert.strictEqual(ev.target.tagName, 'SPAN');
       assert.strictEqual(ev.target.className, 'child');
       assert.strictEqual(ev.target.textContent, 'Hello world');
-      assert.strictEqual(ev.currentTarget.tagName, 'H2');
-      assert.strictEqual(ev.currentTarget.className, 'parent');
+      const currentTargetIsParentH2 =
+        ev.currentTarget.tagName === 'H2' && ev.currentTarget.className === 'parent';
+      const ownerTargetIsParentH2 =
+        ev.ownerTarget.tagName === 'H2' && ev.ownerTarget.className === 'parent';
+      assert.strictEqual(currentTargetIsParentH2 || ownerTargetIsParentH2, true);
       sources.dispose();
       done();
     });

--- a/test/browser/fixtures/issue-89.js
+++ b/test/browser/fixtures/issue-89.js
@@ -13,7 +13,7 @@ function myElement(content) {
 function makeModelNumber$() {
   return Rx.Observable.merge(
     Rx.Observable.just(123).delay(50),
-    Rx.Observable.just(456).delay(200)
+    Rx.Observable.just(456).delay(100)
   );
 }
 

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -168,22 +168,22 @@ describe('DOM Rendering', function () {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
-    sources.DOM.select(':root').observable.skip(1).take(1).subscribe(function (root) {
-      setTimeout(() => {
-        const myelement = root.querySelector('.myelementclass');
+    sources.DOM.select('.myelementclass').observable.skip(1).first() // 1st
+      .subscribe(function (elements) {
+        const myelement = elements[0];
         assert.notStrictEqual(myelement, null);
         assert.strictEqual(myelement.tagName, 'H3');
         assert.strictEqual(myelement.textContent, '123');
-      }, 100);
-      setTimeout(() => {
-        const myelement = root.querySelector('.myelementclass');
+      });
+    sources.DOM.select('.myelementclass').observable.skip(2).first() // 2nd
+      .subscribe(function (elements) {
+        const myelement = elements[0];
         assert.notStrictEqual(myelement, null);
         assert.strictEqual(myelement.tagName, 'H3');
         assert.strictEqual(myelement.textContent, '456');
         sources.dispose();
         done();
-      }, 300);
-    });
+      });
   });
 
   it('should accept a view with VTree$ as the root of VTree', function (done) {
@@ -198,22 +198,22 @@ describe('DOM Rendering', function () {
       DOM: makeDOMDriver(createRenderTarget())
     });
 
-    sources.DOM.select(':root').observable.skip(1).take(1).subscribe(function (root) {
-      setTimeout(() => {
-        const myelement = root.querySelector('.myelementclass');
+    sources.DOM.select('.myelementclass').observable.skip(1).first() // 1st
+      .subscribe(function (elements) {
+        const myelement = elements[0];
         assert.notStrictEqual(myelement, null);
         assert.strictEqual(myelement.tagName, 'H3');
         assert.strictEqual(myelement.textContent, '123');
-      }, 100);
-      setTimeout(() => {
-        const myelement = root.querySelector('.myelementclass');
+      });
+    sources.DOM.select('.myelementclass').observable.skip(2).first() // 1st
+      .subscribe(function (elements) {
+        const myelement = elements[0];
         assert.notStrictEqual(myelement, null);
         assert.strictEqual(myelement.tagName, 'H3');
         assert.strictEqual(myelement.textContent, '456');
         sources.dispose();
         done();
-      }, 300);
-    });
+      });
   });
 
   it('should render a VTree with a child Observable<VTree>', function (done) {


### PR DESCRIPTION
For those cases where currentTarget cannot be mutated in some browsers.