### PR TITLE
Bump hyperscript-helpers to 2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "main": "lib/cycle-dom.js",
   "dependencies": {
-    "hyperscript-helpers": "2.0.2",
+    "hyperscript-helpers": "2.0.3",
     "matches-selector": "1.0.0",
     "vdom-parser": "1.2.1",
     "vdom-to-html": "2.2.0",


### PR DESCRIPTION
This adds the missing `main` tag helper.