### PR TITLE
added `timeupdate` to list eventTypesThatDontBubble

### DIFF
--- a/src/render-dom.js
+++ b/src/render-dom.js
@@ -116,6 +116,7 @@ const eventTypesThatDontBubble = [
   `submit`,
   `change`,
   `reset`,
+  `timeupdate`,
 ]
 
 function maybeMutateEventPropagationAttributes(event) {


### PR DESCRIPTION
added `timeupdate` to list eventTypesThatDontBubble

https://developer.mozilla.org/en-US/docs/Web/Events/timeupdate
https://github.com/cyclejs/cycle-dom/issues/103