### PR TITLE
Add possibility to define the observable in mockDOMSource — refs #106

### DIFF
--- a/src/mock-dom-source.js
+++ b/src/mock-dom-source.js
@@ -18,8 +18,12 @@ function mockDOMSource(mockedSelectors = {}) {
     select(selector) {
       for (const key in mockedSelectors) {
         if (mockedSelectors.hasOwnProperty(key) && key === selector) {
+          let observable = emptyStream
+          if (mockedSelectors[key].hasOwnProperty(`observable`)) {
+            observable = mockedSelectors[key].observable
+          }
           return {
-            observable: emptyStream,
+            observable,
             events: getEventsStreamForSelector(mockedSelectors[key]),
           }
         }

--- a/test/node/mock-dom-source.js
+++ b/test/node/mock-dom-source.js
@@ -69,7 +69,7 @@ describe('mockDOMSource', function () {
       .subscribe(assert.fail, assert.fail, done);
   });
 
-  it('should return empty Observable for select().observable', function (done) {
+  it('should return empty Observable for select().observable and none is defined', function (done) {
     const userEvents = mockDOMSource({
       '.foo': {
         'click': Rx.Observable.just(135)
@@ -78,5 +78,18 @@ describe('mockDOMSource', function () {
     let subscribeExecuted = false;
     userEvents.select('.foo').observable
       .subscribe(assert.fail, assert.fail, done);
+  });
+
+  it('should return defined Observable for select().observable', function (done) {
+    const mockedDOMSource = mockDOMSource({
+      '.foo': {
+        observable: Rx.Observable.just(135)
+      }
+    });
+    mockedDOMSource.select('.foo').observable
+      .subscribe(e => {
+        assert.strictEqual(e, 135)
+        done()
+      });
   });
 });


### PR DESCRIPTION
With this naive implementation, you could do `DOM.select(selector).events('observable')` and get the same observable as `DOM.select(selector).observable`. Not sure if it really is an issue, thoughts?

Also I noticed some dead code in `mock-dom-source.js`, L67 and L78 both the `let subscribeExecuted` are unused.