### PR TITLE
#345 SVG foreignobject support

### DIFF
--- a/src/hyperscript.ts
+++ b/src/hyperscript.ts
@@ -12,14 +12,14 @@ function mutateStreamWithNS(vNode: VNode): VNode {
   return vNode;
 }
 
-function addNS(data: Object, children: Array<VNode | string | Stream<VNode>>): void {
+function addNS(data: Object, children: Array<VNode | string | Stream<VNode>>, selector?: string): void {
   (<any> data).ns = `http://www.w3.org/2000/svg`;
-  if (typeof children !== `undefined` && is.array(children)) {
+  if (selector !== 'foreignObject' && typeof children !== `undefined` && is.array(children)) {
     for (let i = 0; i < children.length; ++i) {
       if (isGenericStream(children[i])) {
         children[i] = (<Stream<VNode>> children[i]).map(mutateStreamWithNS);
       } else {
-        addNS((<VNode> children[i]).data, (<VNode> children[i]).children);
+        addNS((<VNode> children[i]).data, (<VNode> children[i]).children, (<VNode> children[i]).sel);
       }
     }
   }

--- a/src/hyperscript.ts
+++ b/src/hyperscript.ts
@@ -8,13 +8,13 @@ function isGenericStream(x: any): boolean {
 }
 
 function mutateStreamWithNS(vNode: VNode): VNode {
-  addNS(vNode.data, vNode.children);
+  addNS(vNode.data, vNode.children, vNode.sel);
   return vNode;
 }
 
-function addNS(data: Object, children: Array<VNode | string | Stream<VNode>>, selector?: string): void {
+function addNS(data: Object, children: Array<VNode | string | Stream<VNode>>, selector: string): void {
   (<any> data).ns = `http://www.w3.org/2000/svg`;
-  if (selector !== 'foreignObject' && typeof children !== `undefined` && is.array(children)) {
+  if (selector !== `foreignObject` && typeof children !== `undefined` && is.array(children)) {
     for (let i = 0; i < children.length; ++i) {
       if (isGenericStream(children[i])) {
         children[i] = (<Stream<VNode>> children[i]).map(mutateStreamWithNS);
@@ -55,7 +55,7 @@ export function h(sel: string, b?: any, c?: any): VNode {
     }
   }
   if (sel[0] === 's' && sel[1] === 'v' && sel[2] === 'g') {
-    addNS(data, children);
+    addNS(data, children, sel);
   }
   return vnode(sel, data, children, text, undefined);
 };

--- a/test/browser/render.js
+++ b/test/browser/render.js
@@ -185,6 +185,43 @@ describe('DOM Rendering', function () {
     dispose = run();
   });
 
+  it('should render embedded HTML within SVG <foreignObject>', function (done) {
+    function app() {
+      return {
+        DOM: Rx.Observable.of(
+          svg({ attrs: { width: 150, height: 50 }}, [
+            svg.foreignObject({ attrs: { width: '100%', height: '100%' }}, [
+              p('.embedded-text', 'This is HTML embedded in SVG')
+            ])
+          ])
+        )
+      }
+    }
+
+    // Run it
+    const {sinks, sources, run} = Cycle(app, {
+      DOM: makeDOMDriver(createRenderTarget())
+    });
+
+    let dispose;
+
+    // Make assertions
+    sources.DOM.select(':root').elements().skip(1).take(1).subscribe(function (root) {
+      const embeddedHTML = root.querySelector('p.embedded-text');
+
+      assert.strictEqual(embeddedHTML.namespaceURI, 'http://www.w3.org/1999/xhtml');
+      assert.notStrictEqual(embeddedHTML.clientWidth, 0);
+      assert.notStrictEqual(embeddedHTML.clientHeight, 0);
+
+      setTimeout(() => {
+        dispose();
+        done();
+      });
+    });
+
+    dispose = run();
+  });
+
   it('should filter out null/undefined children', function (done) {
 
     // The Cycle.js app


### PR DESCRIPTION
Hi, 

This PR halts the `addNS()` recursion of VNode children if the selector is `foreignObject` so that its children are not incorrectly set to use the SVG namespace:  `http://www.w3.org/2000/svg` and instead retain `http://www.w3.org/1999/xhtml`

Hopefully this is a reasonable fix (at least for the embedded HTML use-case), but if there's a smarter way please let me know.

Discussion: https://github.com/cyclejs/core/issues/345

Thanks!
